### PR TITLE
Fixed check status when generating workflow

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ async function generateWorkflow (file, options) {
         if (response) {
           if (Object.keys(options.check).length !== 0) step.http.check = {}
           if (options.check.status) {
-            step.http.check.status = Object.keys(swagger.paths[path][method].responses)[0] === 'default' ? 200 : Number()
+            step.http.check.status = Number(Object.keys(swagger.paths[path][method].responses)[0])
           }
         }
 

--- a/index.js
+++ b/index.js
@@ -167,7 +167,11 @@ async function generateWorkflow (file, options) {
         if (response) {
           if (Object.keys(options.check).length !== 0) step.http.check = {}
           if (options.check.status) {
-            step.http.check.status = Number(Object.keys(swagger.paths[path][method].responses)[0])
+            step.http.check.status =
+              Object.keys(swagger.paths[path][method].responses)[0] === 'default'
+                ? 200
+                : Number(Object.keys(swagger.paths[path][method].responses)[0])
+
           }
         }
 


### PR DESCRIPTION
Sorry for the sudden PR.
There was a bug when generating a stepci workflow from an openapi definition document that caused the status code confirmation to be 0, so I have fixed it.

As a way to reproduce it, if you run the following code, the http-check-status is correctly 200, but it becomes 0 as shown below.
Any suggestion is welcome, of course.
```js
generateWorkflowFile('./tests/petstore.yaml', 'workflow.yml', {
  generator: {
    pathParams: false
  }
})
```
```yml
tests:
  pet:
    name: Everything about your Pets
    steps:
      - id: updatePet
        name: Update an existing pet
        http:
          check:
            status: 0
```